### PR TITLE
refine the script

### DIFF
--- a/inOS-docker.build.sh
+++ b/inOS-docker.build.sh
@@ -23,24 +23,20 @@ sed -i '$a\CONFIG_EXT2_FS_POSIX_ACL=y' rpmbuild/SOURCES/kernel-3.10.0-x86_64.con
 sed -i '$a\CONFIG_EXT2_FS_SECURITY=y' rpmbuild/SOURCES/kernel-3.10.0-x86_64.config
 
 
-cd ~/rpmbuild/SPECS
-yum-builddep kernel.spec
+pushd ~/rpmbuild/SPECS
+yum-builddep kernel.spec -y
 rpmbuild -ba kernel.spec
+popd
 
 wget -c https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && rpm -ivh epel-release-latest-7.noarch.rpm
 
 yum  -y install lxc*
 
-lxc-create –name docker –t /usr/share/lxc/templates/lxc-centos
+lxc-create --name docker -t /usr/share/lxc/templates/lxc-centos
 
-systemctl start libvirtd
-lxc-start --name docker
-
-yum -y install yum-utils
 yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-yum -y install docker-ce
-
-lxc-stop --name docker
+cp /etc/yum.repos.d/docker-ce.repo /var/lib/lxc/docker/rootfs/etc/yum.repos.d/
+yum -y --installroot=/var/lib/lxc/docker/rootfs install docker-ce
 
 yum -y --installroot=/var/lib/lxc/docker/rootfs install ~/rpmbuild/RPMS/x86_64/kernel-3.10.0-693.5.2.el7.x86_64.rpm
 
@@ -50,18 +46,24 @@ dd if=/dev/zero of=/mnt/initrd.image bs=4096 count=1048576
 mke2fs -F -m 0 -b 4096 /mnt/initrd.image 1048576
 mkdir /ramdisk
 mount -o loop /mnt/initrd.image /ramdisk
-cd /var/lib/lxc/docker/rootfs
-find . –print | cpio –c –o > /mnt/docker.img
-cd /ramdisk
+
+pushd /var/lib/lxc/docker/rootfs
+find . -print | cpio -c -o > /mnt/docker.img
+popd
+
+pushd /ramdisk
 cpio -id < /mnt/docker.img
-cd /mnt
+popd
+
+pushd /mnt
 umount /ramdisk
 gzip -9 initrd.image
 mv initrd.image.gz /boot
+popd
 
 sed -i '$a\menuentry "inOS-docker" {' /boot/grub2/grub.cfg
 sed -i '$a\set root="hd0,msdos1"' /boot/grub2/grub.cfg
-sed -i '$a\    linux /vmlinuz-3.10.0-693.5.2.el7.x86_64 ramdisk_size=4194304' /boot/grub2/grub.cfg
+sed -i '$a\    linux /vmlinuz-3.10.0-693.5.2.el7.x86_64 ramdisk_size=4194304 quiet' /boot/grub2/grub.cfg
 sed -i '$a\    initrd /initrd.image.gz' /boot/grub2/grub.cfg
 sed -i '$a\}' /boot/grub2/grub.cfg
 


### PR DESCRIPTION
Use this script can build a image and boot from ramdisk.
But there is a critical issue can not fix now:
The lxc create a container use a random password for root in file /var/lib/lxc/<containername>/tmp_root_pass. When boot up the container, need to use the random password first and change it. But in the inOS boot from ramdisk, the random password can not login the system.